### PR TITLE
Fix for Windows paths & Spanish language

### DIFF
--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'plugin' => [
+        'name' => 'Quick Edit',
+        'description' => 'Edita rápidamente el contenido de páginas mediante un widget en el dashboard.',
+        'author' => 'Gergő Szabó'
+    ],
+    'widget' => [
+        'type' => 'Tipo',
+        'type_page' => 'Páginas',
+        'type_content' => 'Contenido',
+        'type_static_pages' => 'Páginas estáticas',
+        'type_partials' => 'Parciales',
+        'type_layouts' => 'Plantillas',
+        'editor' => 'Tipo de editor',
+        'editor_none' => 'Ninguno',
+        'editor_rich' => 'Editor enriquecido',
+        'height_title' => 'Altura (en píxeles)',
+        'height_description' => 'No funciona con el editor enriquecido.',
+        'size_title' => 'Tamaño',
+        'size_description' => 'Sólo funciona con el editor enriquecido.',
+        'size_large' => 'Grande',
+        'size_huge' => 'Enorme',
+        'size_giant' => 'Gigante',
+        'theme_title' => 'Mostrar tema por defecto',
+        'theme_description' => 'Lista sólo los archivos del tema activo.',
+        'error_number' => 'El campo solo puede contener números.',
+        'error_page' => 'Por favor selecciona un contenido que editar.',
+        'select' => '-- selecciona --',
+        'modify' => 'Última modificacion',
+        'nodate' => 'sin datos',
+        'permission' => 'Gestiona el widget en el dashboard'
+    ]
+];

--- a/reportwidgets/Qedit.php
+++ b/reportwidgets/Qedit.php
@@ -128,6 +128,7 @@ class Qedit extends ReportWidgetBase
 
         foreach ($files as $file) {
             $file = str_replace(base_path().'/themes/', '', $file);
+            $file = str_replace('\\', '/', $file);
             $path = explode('/', $file);
 
             // Is not a current folder


### PR DESCRIPTION
On Windows system when Qedit is loading files in the foreach of loadData method is throwing an error because the paths has some \ instead /. So before explode the path, convert all \ in /